### PR TITLE
Fix errors when event.data is object, not array

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 module.exports = XDLS;
 
-var md5 = require( 'md5' );
-var dataset = require( 'dataset' );
+var md5 = require('md5');
+var dataset = require('dataset');
 
 var PREFIX = 'xdls:';
 
@@ -15,12 +15,12 @@ var METHODS = [
     'keys',
     'length',
     'removeItem',
-    'setItem'  
+    'setItem'
 ];
 
 var _instanceId = 0;
 
-function XDLS( options ) {
+function XDLS(options) {
     this.origin = options.origin;
     this.path = options.path;
     this.ready = false;
@@ -28,106 +28,106 @@ function XDLS( options ) {
     this.messageId = 0;
     this.callbacks = {};
     this.instanceId = _instanceId++;
-    
-    if ( !( this.origin && this.path ) ) {
-        throw new Error( 'XDLS needs both an origin and a path specified in the constructor options.' );
+
+    if (!(this.origin && this.path)) {
+        throw new Error('XDLS needs both an origin and a path specified in the constructor options.');
     }
-    
-    for ( var i = 0; i < METHODS.length; ++i ) {
-        this[ METHODS[ i ] ] = this._handleMethod.bind( this, METHODS[ i ] );
+
+    for (var i = 0; i < METHODS.length; ++i) {
+        this[METHODS[i]] = this._handleMethod.bind(this, METHODS[i]);
     }
-    
-    if ( typeof( options.init ) === 'undefined' || options.init ) {
+
+    if (typeof (options.init) === 'undefined' || options.init) {
         this.init();
     }
 }
 
-XDLS.prototype.init = function() {
+XDLS.prototype.init = function () {
     var self = this;
-    
-    if ( self._iframe ) {
+
+    if (self._iframe) {
         return;
     }
-    
-    if ( !( window.postMessage && window.JSON ) ) {
-        throw new Error( 'XDLS requires both postMossage and JSON support.' );
+
+    if (!(window.postMessage && window.JSON)) {
+        throw new Error('XDLS requires both postMossage and JSON support.');
     }
 
-    var onLoaded = self._onLoaded.bind( self );
-    var onMessage = self._onMessage.bind( self );
+    var onLoaded = self._onLoaded.bind(self);
+    var onMessage = self._onMessage.bind(self);
 
-    var iframeID = 'xdls-' + md5.digest_s( self.origin + self.path );
-    
-    var existingIframe = document.getElementById( iframeID );
-    if ( existingIframe ) {
+    var iframeID = 'xdls-' + md5.digest_s(self.origin + self.path);
+
+    var existingIframe = document.getElementById(iframeID);
+    if (existingIframe) {
         self._iframe = existingIframe;
-        if ( dataset( self._iframe, 'loaded' ) ) {
+        if (dataset(self._iframe, 'loaded')) {
             onLoaded();
         }
     }
     else {
-        self._iframe = document.createElement( 'iframe' );
+        self._iframe = document.createElement('iframe');
         self._iframe.id = iframeID;
-        self._iframe.setAttribute( 'sandbox', 'allow-scripts allow-same-origin' );
-        dataset( self._iframe, 'origin', self.origin );
-        dataset( self._iframe, 'path', self.path );
+        self._iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+        dataset(self._iframe, 'origin', self.origin);
+        dataset(self._iframe, 'path', self.path);
         self._iframe.style.cssText = 'width:1px; height:1px; display: none;';
         (function _addIframe() {
-            if ( document.body ) {
-                document.body.appendChild( self._iframe );
+            if (document.body) {
+                document.body.appendChild(self._iframe);
                 return;
             }
-            
-            setTimeout( _addIframe, 100 );
+
+            setTimeout(_addIframe, 100);
         })();
     }
 
-    if ( window.addEventListener ) {
-        self._iframe.addEventListener( 'load', onLoaded, false );
-        window.addEventListener( 'message', onMessage, false );
+    if (window.addEventListener) {
+        self._iframe.addEventListener('load', onLoaded, false);
+        window.addEventListener('message', onMessage, false);
     }
-    else if ( self._iframe.attachEvent ) {
-        self._iframe.attachEvent( 'onload', onLoaded, false);
-        window.attachEvent( 'onmessage', onMessage );
+    else if (self._iframe.attachEvent) {
+        self._iframe.attachEvent('onload', onLoaded, false);
+        window.attachEvent('onmessage', onMessage);
     }
     else {
-        throw new Error( 'XDLS could not properly bind for event handling.' );
+        throw new Error('XDLS could not properly bind for event handling.');
     }
 
-    if ( !existingIframe ) {
+    if (!existingIframe) {
         self._iframe.src = self.origin + self.path;
     }
 };
 
-XDLS.prototype._onLoaded = function() {
+XDLS.prototype._onLoaded = function () {
     var self = this;
-    
+
     self.ready = true;
-    dataset( self._iframe, 'loaded', true );
-    
+    dataset(self._iframe, 'loaded', true);
+
     var message;
-    while ( ( message = self.queue.shift() ) ) {
-        self._sendMessage( message );
+    while ((message = self.queue.shift())) {
+        self._sendMessage(message);
     }
 };
 
-XDLS.prototype._handleMethod = function() {
+XDLS.prototype._handleMethod = function () {
     var self = this;
-    var _args = Array.prototype.slice.call( arguments, 0 ); // convert arguments to an array
+    var _args = Array.prototype.slice.call(arguments, 0); // convert arguments to an array
     var method = _args.shift();
     var callback = null;
-    
+
     self.init();
-    
-    if ( _args.length && typeof( _args[ _args.length - 1 ] ) === 'function' ) {
+
+    if (_args.length && typeof (_args[_args.length - 1]) === 'function') {
         callback = _args.pop();
     }
 
     ++self.messageId;
     var id = self.instanceId + '.' + self.messageId;
-    
-    if ( callback ) {
-        self.callbacks[ id ] = callback;
+
+    if (callback) {
+        self.callbacks[id] = callback;
     }
 
     var message = {
@@ -135,37 +135,37 @@ XDLS.prototype._handleMethod = function() {
         method: method,
         arguments: _args
     };
-    
-    if ( self.ready ) {
-        self._sendMessage( message );
+
+    if (self.ready) {
+        self._sendMessage(message);
     }
     else {
-        self.queue.push( message );
+        self.queue.push(message);
     }
 };
 
-XDLS.prototype._sendMessage = function( message ) {
+XDLS.prototype._sendMessage = function (message) {
     var self = this;
-    self._iframe.contentWindow.postMessage( PREFIX + JSON.stringify( message ), self.origin );
+    self._iframe.contentWindow.postMessage(PREFIX + JSON.stringify(message), self.origin);
 };
 
-XDLS.prototype._onMessage = function( event ) {
+XDLS.prototype._onMessage = function (event) {
     var self = this;
-    
-    if ( ( !event.origin || self.origin.indexOf( event.origin ) === -1 ) || ( !event.data || event.data.indexOf( PREFIX ) !== 0 ) ) {
+
+    if ((!event.origin || self.origin.indexOf(event.origin) === -1) || (!event.data || !event.data.indexOf || event.data.indexOf(PREFIX) !== 0)) {
         return;
     }
-    
-    var data = JSON.parse( event.data.substring( PREFIX.length ) );
-    
-    if ( self.callbacks[ data.id ] ) {
-        if ( data.error ) {
-            self.callbacks[ data.id ]( data );
+
+    var data = JSON.parse(event.data.substring(PREFIX.length));
+
+    if (self.callbacks[data.id]) {
+        if (data.error) {
+            self.callbacks[data.id](data);
         }
         else {
-            self.callbacks[ data.id ]( null, data.result );
+            self.callbacks[data.id](null, data.result);
         }
 
-        delete self.callbacks[ data.id ];
+        delete self.callbacks[data.id];
     }
 };

--- a/xdls.html
+++ b/xdls.html
@@ -1,74 +1,76 @@
 <!doctype html>
 <html>
-    <body>
-        <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/localforage/1.2.1/localforage.min.js"></script>
-        <script>
-            var PREFIX = 'xdls:';
-            localforage.config( {
-                size: 4000000, // safari seems to complain now with the default size so back off a bit
-                name: 'XDLS'
-            } );
 
-            function onLocalForageComplete( event, data, error, result ) {
-                if ( error ) {
-                    event.source.postMessage( PREFIX + JSON.stringify( {
-                        id: data.id,
-                        error: 'localforage error',
-                        message: error.message || error
-                    } ), event.origin );
-                    return;
-                }
+<body>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/localforage/1.2.1/localforage.min.js"></script>
+    <script>
+        var PREFIX = 'xdls:';
+        localforage.config({
+            size: 4000000, // safari seems to complain now with the default size so back off a bit
+            name: 'XDLS'
+        });
 
-                event.source.postMessage( PREFIX + JSON.stringify( {
+        function onLocalForageComplete(event, data, error, result) {
+            if (error) {
+                event.source.postMessage(PREFIX + JSON.stringify({
                     id: data.id,
-                    result: result
-                } ), event.origin );
+                    error: 'localforage error',
+                    message: error.message || error
+                }), event.origin);
+                return;
             }
 
-            function onMessage( event ) {
-                if ( event.data.indexOf( PREFIX ) !== 0 ) {
-                    return;
-                }
+            event.source.postMessage(PREFIX + JSON.stringify({
+                id: data.id,
+                result: result
+            }), event.origin);
+        }
 
-                // remove the xdls: header and parse
-                try {
-                    var data = JSON.parse( event.data.substring( PREFIX.length ) );
-                }
-                catch( ex ) {
-                    event.source.postMessage( PREFIX + JSON.stringify( {
-                        error: 'invalid xdls message',
-                        message: 'Could not parse xdls message: ' + event.data
-                    } ), event.origin );
-                    return;
-                }
-
-                var method = data.method;
-
-                if ( !localforage.hasOwnProperty( method ) ) {
-                    event.source.postMessage( PREFIX + JSON.stringify( {
-                        id: data.id,
-                        error: 'invalid method',
-                        message: 'Invalid xdls method specified: ' + method
-                    } ), event.origin );
-                    return;
-                }
-
-                try {
-                    var arguments = data.arguments || [];
-                    arguments.push( onLocalForageComplete.bind( null, event, data ) );
-                    localforage[ method ].apply( localforage, data.arguments );
-                }
-                catch ( ex ) {
-                    onLocalForageComplete( event, data, ex );
-                }
+        function onMessage(event) {
+            if (!event.data.indexOf || event.data.indexOf(PREFIX) !== 0) {
+                return;
             }
 
-            if( window.addEventListener ) {
-                window.addEventListener( 'message', onMessage, false );
+            // remove the xdls: header and parse
+            try {
+                var data = JSON.parse(event.data.substring(PREFIX.length));
             }
-            else if ( window.attachEvent ) {
-                window.attachEvent( 'onmessage', onMessage );
+            catch (ex) {
+                event.source.postMessage(PREFIX + JSON.stringify({
+                    error: 'invalid xdls message',
+                    message: 'Could not parse xdls message: ' + event.data
+                }), event.origin);
+                return;
             }
-        </script>
-    </body>
+
+            var method = data.method;
+
+            if (!localforage.hasOwnProperty(method)) {
+                event.source.postMessage(PREFIX + JSON.stringify({
+                    id: data.id,
+                    error: 'invalid method',
+                    message: 'Invalid xdls method specified: ' + method
+                }), event.origin);
+                return;
+            }
+
+            try {
+                var arguments = data.arguments || [];
+                arguments.push(onLocalForageComplete.bind(null, event, data));
+                localforage[method].apply(localforage, data.arguments);
+            }
+            catch (ex) {
+                onLocalForageComplete(event, data, ex);
+            }
+        }
+
+        if (window.addEventListener) {
+            window.addEventListener('message', onMessage, false);
+        }
+        else if (window.attachEvent) {
+            window.attachEvent('onmessage', onMessage);
+        }
+    </script>
+</body>
+
 </html>


### PR DESCRIPTION
Not entirely sure the root of this issue. I'm receiving an object back
from event.data in some of the onMessage events. There are already some
short-circuits for when the array doesn't contain the key. This adds a
check for indexOf prior to the call.